### PR TITLE
Fix gradle by updating rhino version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,6 @@ create_file_id=3499718
 jei_version=1.16.4:7.6.1.74
 flywheel_version=1.16-0.2.3.44
 kubejs_version=1605.3.18-build.152
-rhino_version=1605.1.2-build.48
+rhino_version=1605.1.4-build.67
 architectury_version=1.20.28
 #crafttweaker_version=1.16.5:7.1.0.366


### PR DESCRIPTION
apparently the reason it failed was because the methods were moved from kubejs to rhino, and only one was updated:

![Screen Shot 2021-10-31 at 16 12 50](https://user-images.githubusercontent.com/3179271/139590732-8c019957-67b5-4dce-b734-493d1edfb8c4.png)

the commit: https://github.com/KubeJS-Mods/Rhino/commit/03b0611ea8da9e754cec941eeb9b28848cdc8dd6